### PR TITLE
When port is already in use, gearbox fails silently - trace error on stdout

### DIFF
--- a/gearbox/commands/serve.py
+++ b/gearbox/commands/serve.py
@@ -1010,7 +1010,12 @@ def cherrypy_server_runner(
                   (port, protocol, port))
         else:
             print('serving on %s://%s:%s' % (protocol, host, port))
-        server.start()
+
+        try:
+            server.start()
+        except Exception as e:
+            print('fail starting HTTP server. The error was: %s' % e)
+        
     except (KeyboardInterrupt, SystemExit):
         server.stop()
 


### PR DESCRIPTION
trace start failure on stdout in case the server fails to run, for example when port is already in use
