### PR TITLE
Deprecation warning

### DIFF
--- a/gearbox/main.py
+++ b/gearbox/main.py
@@ -156,7 +156,7 @@ class GearBox(object):
 
         cmd_factory, cmd_name, sub_argv = subcommand
         kwargs = {}
-        if 'cmd_name' in inspect.getargspec(cmd_factory.__init__).args:
+        if 'cmd_name' in inspect.signature(cmd_factory.__init__).args:
             kwargs['cmd_name'] = cmd_name
         cmd = cmd_factory(self, self.options, **kwargs)
 


### PR DESCRIPTION
.../lib/python3.5/site-packages/gearbox/main.py:159: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead