### PR TITLE
Fix ThreadingMixIn import for Python 3

### DIFF
--- a/gearbox/commands/serve.py
+++ b/gearbox/commands/serve.py
@@ -689,7 +689,10 @@ def wsgiref_server_runner(wsgi_app, global_conf, **kw): # pragma: no cover
         server_class = SecureWSGIServer
 
     if threaded:
-        from SocketServer import ThreadingMixIn
+        try:
+            from socketserver import ThreadingMixIn
+        except ImportError:
+            from SocketServer import ThreadingMixIn
         class GearboxWSGIServer(ThreadingMixIn, server_class): pass
         server_type = 'Threaded'
     else:


### PR DESCRIPTION
* SocketServer was renamed to socketserver in Python 3.