### PR TITLE
[PR #26] When using "gearbox serve" with the "-l <logfile>" argument, sys.stdo…

### DIFF
--- a/gearbox/commands/serve.py
+++ b/gearbox/commands/serve.py
@@ -124,7 +124,7 @@ class ServeCommand(Command):
                 dest='set_group',
                 metavar="GROUP",
                 help="Set the group (usually only possible when run as root)")
-    
+
         parser.add_argument(
             '--stop-daemon',
             dest='stop_daemon',
@@ -558,6 +558,8 @@ class LazyWriter(object):
     to.
     """
 
+    buffer = property(lambda x: x.open(), None, None)
+
     def __init__(self, filename, mode='w'):
         self.filename = filename
         self.fileobj = None
@@ -717,7 +719,7 @@ def gevent_server_factory(global_config, **kw):
     from gevent.monkey import patch_all
     reinit()
     patch_all(dns=False)
-    
+
     host = kw.get('host', '0.0.0.0')
     port = int(kw.get('port', 8080))
 


### PR DESCRIPTION
More information in #26 

#…ut gets wrapped in LazyWriter.  LazyWriter does not support the full _io.TextIOWrapper interface -- specifically the buffer property.  This causes applications, like Kallithea, to crash on started when using the command line log file.

The fix is to make access to the buffer property call open and return the file object.  This will cause the file to be created and opened immediately, which LazyWriter was intended to avoid.