### PR TITLE
remove dependency on deprecated pkg_resources

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,14 +6,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run ruff
         uses: astral-sh/ruff-action@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,5 +1,9 @@
 name: Tests and Checks
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
 jobs:
   build:
     name: Run checks & tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/gearbox/commands/scaffold.py
+++ b/gearbox/commands/scaffold.py
@@ -5,7 +5,6 @@ from argparse import RawDescriptionHelpFormatter
 
 from gearbox.command import Command
 from gearbox.template import GearBoxTemplate
-from gearbox.utils.plugins import find_egg_info_dir
 
 
 class ScaffoldCommand(Command):
@@ -61,6 +60,7 @@ templates/template.html.template scaffolds of the current project.
             "-np",
             "--no-package",
             dest="nopackage",
+            action="store_true",
             help="When using subdir option do not create python "
             "packages, but plain directories.",
         )
@@ -76,27 +76,6 @@ templates/template.html.template scaffolds of the current project.
                     template_filename = os.path.join(root, f)
                     break
         return template_filename
-
-    def _find_toplevel_packages(self):
-        egg_info_dir = find_egg_info_dir(os.getcwd())
-        if egg_info_dir is None:
-            print(
-                "Unable to find distribution egg-info, did you run setup.py egg_info or develop?"
-            )
-            return []
-
-        modules = os.path.join(egg_info_dir, "top_level.txt")
-        try:
-            modules = open(modules).readlines()
-        except Exception:
-            print("Unable to detect distribution top level packages.")
-            return []
-
-        modules = map(lambda x: x.strip().replace(os.sep, "."), modules)
-        modules = filter(
-            lambda x: not x.startswith("test"), modules
-        )  # Remove test suite modules
-        return list(modules)
 
     def take_action(self, opts):
         for template in opts.scaffold_name:
@@ -136,7 +115,7 @@ templates/template.html.template scaffolds of the current project.
 
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
-                if opts.subdir:
+                if opts.subdir and not opts.nopackage:
                     package_init = os.path.join(output_dir, "__init__.py")
                     if not os.path.exists(package_init):
                         with open(package_init, "w") as pif:
@@ -157,7 +136,6 @@ templates/template.html.template scaffolds of the current project.
                             "subdir": opts.subdir,
                             "subpackage": subdir_as_package,
                             "dotted_subpackage": "." + subdir_as_package,
-                            "packages": self._find_toplevel_packages(),
                         },
                     )
                 except NameError as e:

--- a/gearbox/main.py
+++ b/gearbox/main.py
@@ -272,8 +272,9 @@ class GearBox(object):
 
         if not found_distribution:
             log.error(
-                "Failed to load project commands with error "
-                "``%s``, have you installed your project?" % package_name
+                "Failed to load project commands for package '%s'. "
+                "Have you installed your project?",
+                package_name,
             )
 
     @staticmethod

--- a/gearbox/main.py
+++ b/gearbox/main.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 
 import argparse
+import importlib.metadata
 import inspect
 import logging
 import os
+import re
 import sys
 import warnings
 
-import pkg_resources
-
 from .commandmanager import CommandManager
 from .commands.help import HelpAction, HelpCommand
-from .utils.plugins import find_egg_info_dir
+from .utils.plugins import find_local_distribution
 
 log = logging.getLogger("gearbox")
 
@@ -24,6 +24,11 @@ class GearBox(object):
     )
     DEFAULT_VERBOSE_LEVEL = 1
 
+    try:
+        VERSION = importlib.metadata.version("gearbox")
+    except importlib.metadata.PackageNotFoundError:
+        VERSION = "unknown"
+
     def __init__(self):
         self.command_manager = CommandManager("gearbox.commands")
         self.command_manager.add_command("help", HelpCommand)
@@ -35,9 +40,7 @@ class GearBox(object):
         parser.add_argument(
             "--version",
             action="version",
-            version="%(prog)s {0}".format(
-                pkg_resources.get_distribution("gearbox").version
-            ),
+            version="%(prog)s {0}".format(self.VERSION),
         )
 
         verbose_group = parser.add_mutually_exclusive_group()
@@ -136,20 +139,8 @@ class GearBox(object):
             if self.options.relative_plugins:
                 curdir = os.getcwd()
                 sys.path.insert(0, curdir)
-                pkg_resources.working_set.add_entry(curdir)
 
-            try:
-                self._load_commands_for_current_dir()
-            except pkg_resources.DistributionNotFound as e:
-                try:
-                    error_msg = repr(e)
-                except Exception:
-                    error_msg = "Unknown Error"
-
-                log.error(
-                    "Failed to load project commands with error "
-                    "``%s``, have you installed your project?" % error_msg
-                )
+            self._load_commands_for_current_dir()
 
         except Exception as err:
             if hasattr(self, "options"):
@@ -194,31 +185,100 @@ class GearBox(object):
             return 4
 
     def _load_commands_for_current_dir(self):
-        egg_info_dir = find_egg_info_dir(os.getcwd())
-        if egg_info_dir:
-            package_name = os.path.splitext(os.path.basename(egg_info_dir))[0]
+        dist, search_path = find_local_distribution(os.getcwd(), "gearbox.plugins")
+        if dist is None:
+            return
+
+        for ep in dist.entry_points:
+            if ep.group == "gearbox.plugins":
+                self.load_commands_for_package(ep.module, search_paths=[search_path])
+
+    def load_commands_for_package(self, package_name, search_paths=None):
+        candidates = [package_name]
+        top_level_package = package_name.split(".", 1)[0]
+        for candidate in importlib.metadata.packages_distributions().get(
+            top_level_package, []
+        ):
+            if candidate not in candidates:
+                candidates.append(candidate)
+
+        local_distributions = []
+        if search_paths:
+            for path in search_paths:
+                if not path:
+                    continue
+                local_distributions.extend(importlib.metadata.distributions(path=[path]))
+
+        normalized_candidates = set(
+            self._normalize_dist_name(name) for name in candidates
+        )
+        local_candidate_distributions = []
+
+        for dist in local_distributions:
+            matched = False
+            dist_name = dist.metadata.get("Name")
+            if (
+                dist_name
+                and self._normalize_dist_name(dist_name) in normalized_candidates
+            ):
+                candidate_name = dist_name
+                if candidate_name not in candidates:
+                    candidates.append(candidate_name)
+                matched = True
+
+            top_level_names = dist.read_text("top_level.txt")
+            if top_level_names:
+                for top_level_name in top_level_names.splitlines():
+                    if top_level_name.strip() == top_level_package:
+                        candidate_name = dist.metadata.get("Name")
+                        if candidate_name and candidate_name not in candidates:
+                            candidates.append(candidate_name)
+                        matched = True
+                        break
+            if matched:
+                local_candidate_distributions.append(dist)
+
+        found_distribution = False
+        for dist in local_candidate_distributions:
+            found_distribution = True
+            loaded_commands = False
+            for ep in dist.entry_points:
+                if ep.group == "gearbox.project_commands":
+                    self.command_manager.commands[ep.name.replace("_", " ")] = ep
+                    loaded_commands = True
+            if loaded_commands:
+                return
+
+        for candidate in candidates:
+            if any(
+                self._normalize_dist_name(dist.metadata.get("Name", ""))
+                == self._normalize_dist_name(candidate)
+                for dist in local_candidate_distributions
+            ):
+                continue
 
             try:
-                pkg_resources.require(package_name)
-            except pkg_resources.DistributionNotFound as e:
-                msg = "%sNot Found%s: %s (is it an installed Distribution?)"
-                if str(e) != package_name:
-                    raise pkg_resources.DistributionNotFound(
-                        msg % (str(e) + ": ", " for", package_name)
-                    )
-                else:
-                    raise pkg_resources.DistributionNotFound(
-                        msg % ("", "", package_name)
-                    )
+                dist = importlib.metadata.distribution(candidate)
+            except importlib.metadata.PackageNotFoundError:
+                continue
+            found_distribution = True
+            loaded_commands = False
+            for ep in dist.entry_points:
+                if ep.group == "gearbox.project_commands":
+                    self.command_manager.commands[ep.name.replace("_", " ")] = ep
+                    loaded_commands = True
+            if loaded_commands:
+                return
 
-            dist = pkg_resources.get_distribution(package_name)
-            for epname, ep in dist.get_entry_map("gearbox.plugins").items():
-                self.load_commands_for_package(ep.module_name)
+        if not found_distribution:
+            log.error(
+                "Failed to load project commands with error "
+                "``%s``, have you installed your project?" % package_name
+            )
 
-    def load_commands_for_package(self, package_name):
-        dist = pkg_resources.get_distribution(package_name)
-        for epname, ep in dist.get_entry_map("gearbox.project_commands").items():
-            self.command_manager.commands[epname.replace("_", " ")] = ep
+    @staticmethod
+    def _normalize_dist_name(name):
+        return re.sub(r"[-_.]+", "-", name).lower()
 
     def _getargspec(self, func):
         if not hasattr(inspect, "signature"):

--- a/gearbox/main.py
+++ b/gearbox/main.py
@@ -207,7 +207,8 @@ class GearBox(object):
             for path in search_paths:
                 if not path:
                     continue
-                local_distributions.extend(importlib.metadata.distributions(path=[path]))
+                path_distributions = importlib.metadata.distributions(path=[path])
+                local_distributions.extend(path_distributions)
 
         normalized_candidates = set(
             self._normalize_dist_name(name) for name in candidates

--- a/gearbox/utils/plugins.py
+++ b/gearbox/utils/plugins.py
@@ -3,10 +3,10 @@ import os
 
 
 def find_local_distribution(start_dir, entry_point_group=None):
-    dir = os.path.abspath(start_dir)
+    current_dir = os.path.abspath(start_dir)
     while True:
         try:
-            distributions = importlib.metadata.distributions(path=[dir])
+            distributions = importlib.metadata.distributions(path=[current_dir])
         except (OSError, PermissionError):
             distributions = ()
 
@@ -14,10 +14,10 @@ def find_local_distribution(start_dir, entry_point_group=None):
             if entry_point_group is None or any(
                 ep.group == entry_point_group for ep in dist.entry_points
             ):
-                return dist, dir
+                return dist, current_dir
 
-        parent = os.path.dirname(dir)
-        if parent == dir:
+        parent = os.path.dirname(current_dir)
+        if parent == current_dir:
             # Top-most directory
             return None, None
-        dir = parent
+        current_dir = parent

--- a/gearbox/utils/plugins.py
+++ b/gearbox/utils/plugins.py
@@ -5,7 +5,12 @@ import os
 def find_local_distribution(start_dir, entry_point_group=None):
     dir = os.path.abspath(start_dir)
     while True:
-        for dist in importlib.metadata.distributions(path=[dir]):
+        try:
+            distributions = importlib.metadata.distributions(path=[dir])
+        except (OSError, PermissionError):
+            distributions = ()
+
+        for dist in distributions:
             if entry_point_group is None or any(
                 ep.group == entry_point_group for ep in dist.entry_points
             ):

--- a/gearbox/utils/plugins.py
+++ b/gearbox/utils/plugins.py
@@ -1,18 +1,18 @@
+import importlib.metadata
 import os
 
 
-def find_egg_info_dir(dir):
-    while 1:
-        try:
-            filenames = os.listdir(dir)
-        except OSError:
-            # Probably permission denied or something
-            return None
-        for fn in filenames:
-            if fn.endswith(".egg-info") and os.path.isdir(os.path.join(dir, fn)):
-                return os.path.join(dir, fn)
+def find_local_distribution(start_dir, entry_point_group=None):
+    dir = os.path.abspath(start_dir)
+    while True:
+        for dist in importlib.metadata.distributions(path=[dir]):
+            if entry_point_group is None or any(
+                ep.group == entry_point_group for ep in dist.entry_points
+            ):
+                return dist, dir
+
         parent = os.path.dirname(dir)
         if parent == dir:
             # Top-most directory
-            return None
+            return None, None
         dir = parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "gearbox"
 version = "0.3.1"
 description = "Command line toolkit born as a PasteScript replacement for the TurboGears2 web framework"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["web framework", "command-line", "setup"]
 license = { text = "MIT" }
 authors = [
@@ -20,7 +20,6 @@ classifiers = [
     "Framework :: TurboGears",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -67,7 +66,7 @@ gevent = "gearbox.commands.serve:gevent_server_factory"
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 output-format = "grouped"
 lint.select = ["E4", "E7", "E9", "F", "I001"]
 exclude = ["build", "dist", ".venv", "venv", "env", "__pycache__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "gearbox"
 version = "0.3.1"
 description = "Command line toolkit born as a PasteScript replacement for the TurboGears2 web framework"
 readme = "README.rst"
+requires-python = ">=3.9"
 keywords = ["web framework", "command-line", "setup"]
 license = { text = "MIT" }
 authors = [
@@ -19,12 +20,12 @@ classifiers = [
     "Framework :: TurboGears",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: WSGI",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
@@ -66,7 +67,7 @@ gevent = "gearbox.commands.serve:gevent_server_factory"
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py39"
 output-format = "grouped"
 lint.select = ["E4", "E7", "E9", "F", "I001"]
 exclude = ["build", "dist", ".venv", "venv", "env", "__pycache__"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.metadata
 import sys
 import tempfile
 from unittest.mock import MagicMock, patch
@@ -7,9 +8,49 @@ import pytest
 
 from gearbox.commandmanager import CommandManager
 from gearbox.commands.help import HelpAction
+from gearbox.commands.scaffold import ScaffoldCommand
 from gearbox.commands.serve import ServeCommand
 from gearbox.commands.setup_app import SetupAppCommand
-from gearbox.main import main
+from gearbox.main import GearBox, main
+
+
+def _write_dist_info(
+    base_dir,
+    name,
+    version,
+    entry_points_text="",
+    package_files=None,
+    top_level_text="",
+):
+    dist_info_dir = base_dir / f"{name}-{version}.dist-info"
+    dist_info_dir.mkdir()
+    metadata = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+    (dist_info_dir / "METADATA").write_text(metadata)
+    if entry_points_text:
+        (dist_info_dir / "entry_points.txt").write_text(entry_points_text)
+    if top_level_text:
+        (dist_info_dir / "top_level.txt").write_text(top_level_text)
+    if package_files:
+        record_entries = []
+        for package_file in package_files:
+            package_path = base_dir / package_file
+            package_path.parent.mkdir(parents=True, exist_ok=True)
+            package_path.write_text("")
+            record_entries.append(f"{package_file},,")
+        (dist_info_dir / "RECORD").write_text("\n".join(record_entries) + "\n")
+    return dist_info_dir
+
+
+def _write_egg_info(base_dir, name, version, entry_points_text="", top_level_text=""):
+    egg_info_dir = base_dir / f"{name}.egg-info"
+    egg_info_dir.mkdir()
+    pkg_info = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+    (egg_info_dir / "PKG-INFO").write_text(pkg_info)
+    if entry_points_text:
+        (egg_info_dir / "entry_points.txt").write_text(entry_points_text)
+    if top_level_text:
+        (egg_info_dir / "top_level.txt").write_text(top_level_text)
+    return egg_info_dir
 
 
 # --- Test for ServeCommand using external wsgiref ---
@@ -167,3 +208,189 @@ def test_patch(tmp_path):
 
     content = test_file.read_text()
     assert "Gearbox" in content
+
+
+def test_loads_local_plugins_metadata_and_calls_project_package_loader():
+    app = GearBox()
+    plugin_ep = MagicMock(name="turbogears-devtools", group="gearbox.plugins")
+    plugin_ep.module = "tg.devtools"
+    dist = MagicMock()
+    dist.entry_points = [plugin_ep]
+
+    with patch(
+        "gearbox.main.find_local_distribution", return_value=(dist, ".")
+    ):
+        with patch.object(app, "load_commands_for_package") as load_package:
+            app._load_commands_for_current_dir()
+
+    load_package.assert_called_once_with("tg.devtools", search_paths=["."])
+
+
+def test_loads_tg_devtools_project_commands_from_project_plugins():
+    app = GearBox()
+    project_plugin_ep = MagicMock(group="gearbox.plugins")
+    project_plugin_ep.name = "turbogears-devtools"
+    project_plugin_ep.module = "tg.devtools"
+    project_dist = MagicMock()
+    project_dist.entry_points = [project_plugin_ep]
+
+    migrate_ep = MagicMock(group="gearbox.project_commands")
+    migrate_ep.name = "migrate"
+    tgshell_ep = MagicMock(group="gearbox.project_commands")
+    tgshell_ep.name = "tgshell"
+    devtools_dist = MagicMock()
+    devtools_dist.entry_points = [migrate_ep, tgshell_ep]
+
+    with patch(
+        "gearbox.main.find_local_distribution",
+        return_value=(project_dist, "."),
+    ), patch(
+        "importlib.metadata.distribution", return_value=devtools_dist
+    ):
+        app._load_commands_for_current_dir()
+
+    assert app.command_manager.commands["migrate"] is migrate_ep
+    assert app.command_manager.commands["tgshell"] is tgshell_ep
+
+
+def test_load_commands_for_package_adds_project_commands_with_spaces():
+    app = GearBox()
+    app.command_manager.commands = {}
+    command_ep = MagicMock(group="gearbox.project_commands")
+    command_ep.name = "foo_bar"
+    dist = MagicMock()
+    dist.entry_points = [command_ep]
+
+    with patch("importlib.metadata.distribution", return_value=dist):
+        app.load_commands_for_package("tg.devtools")
+
+    assert app.command_manager.commands["foo bar"] is command_ep
+
+
+def test_command_manager_loads_tgext_pluggable_style_global_commands():
+    quickstart_ep = MagicMock()
+    quickstart_ep.name = "quickstart-pluggable"
+    migrate_ep = MagicMock()
+    migrate_ep.name = "migrate-pluggable"
+    plugin_eps = [quickstart_ep, migrate_ep]
+
+    class EntryPointSet:
+        def select(self, group):
+            if group == "gearbox.commands":
+                return plugin_eps
+            return []
+
+    with patch("gearbox.commandmanager.importlib.metadata.entry_points") as entry_points:
+        entry_points.return_value = EntryPointSet()
+        cm = CommandManager(namespace="gearbox.commands")
+
+    assert cm.commands["quickstart-pluggable"] is quickstart_ep
+    assert cm.commands["migrate-pluggable"] is migrate_ep
+
+
+def test_loads_tg_devtools_commands_from_local_dist_info(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    nested_cwd = project_root / "app" / "pkg"
+    nested_cwd.mkdir(parents=True)
+    project_entry_points = (
+        "[gearbox.plugins]\n"
+        "turbogears-devtools = tg.devtools\n"
+    )
+    devtools_entry_points = (
+        "[gearbox.project_commands]\n"
+        "local_migrate_distinfo = devtools.gearbox.alembic_migrate:MigrateCommand\n"
+        "local_tgshell_distinfo = devtools.gearbox.tgshell:ShellCommand\n"
+    )
+    _write_dist_info(project_root, "sampleproject", "0.1.0", project_entry_points)
+    _write_dist_info(
+        project_root,
+        "TurboGears2.devtools",
+        "2.5.0",
+        devtools_entry_points,
+        package_files=["tg/devtools/__init__.py"],
+        top_level_text="tg\n",
+    )
+
+    monkeypatch.chdir(nested_cwd)
+    app = GearBox()
+    app._load_commands_for_current_dir()
+
+    assert "local migrate distinfo" in app.command_manager.commands
+    assert "local tgshell distinfo" in app.command_manager.commands
+
+
+def test_loads_tgext_pluggable_global_commands_from_dist_info(tmp_path, monkeypatch):
+    plugin_root = tmp_path / "plugins"
+    plugin_root.mkdir()
+    tgext_entry_points = (
+        "[gearbox.commands]\n"
+        "plug-local-distinfo = tgext.pluggable.commands.plug:PlugApplicationCommand\n"
+        "quickstart-pluggable-local-distinfo = tgext.pluggable.commands.quickstart:QuickstartPluggableCommand\n"
+    )
+    _write_dist_info(plugin_root, "tgext.pluggable", "0.8.5", tgext_entry_points)
+
+    monkeypatch.syspath_prepend(str(plugin_root))
+    command_manager = CommandManager(namespace="gearbox.commands")
+
+    assert "plug-local-distinfo" in command_manager.commands
+    assert "quickstart-pluggable-local-distinfo" in command_manager.commands
+
+
+def test_loads_tg_devtools_commands_from_local_egg_info(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    nested_cwd = project_root / "app" / "pkg"
+    nested_cwd.mkdir(parents=True)
+    project_entry_points = (
+        "[gearbox.plugins]\n"
+        "turbogears-devtools = tg.devtools\n"
+    )
+    devtools_entry_points = (
+        "[gearbox.project_commands]\n"
+        "local_migrate_egginfo = devtools.gearbox.alembic_migrate:MigrateCommand\n"
+        "local_tgshell_egginfo = devtools.gearbox.tgshell:ShellCommand\n"
+    )
+    _write_egg_info(project_root, "sampleproject", "0.1.0", project_entry_points)
+    _write_egg_info(
+        project_root,
+        "TurboGears2.devtools",
+        "2.5.0",
+        devtools_entry_points,
+        top_level_text="tg\n",
+    )
+    (project_root / "tg").mkdir()
+    (project_root / "tg" / "__init__.py").write_text("")
+
+    monkeypatch.chdir(nested_cwd)
+    app = GearBox()
+    app._load_commands_for_current_dir()
+
+    assert "local migrate egginfo" in app.command_manager.commands
+    assert "local tgshell egginfo" in app.command_manager.commands
+
+
+def test_run_continues_when_project_distribution_is_missing():
+    app = GearBox()
+    plugin_ep = MagicMock(name="turbogears-devtools", group="gearbox.plugins")
+    plugin_ep.module = "tg.devtools"
+    project_dist = MagicMock()
+    project_dist.entry_points = [plugin_ep]
+
+    with patch(
+        "gearbox.main.find_local_distribution",
+        return_value=(project_dist, "."),
+    ), patch(
+        "importlib.metadata.distribution",
+        side_effect=importlib.metadata.PackageNotFoundError("tg.devtools"),
+    ), patch.object(app, "_run_subcommand", return_value=42) as run_subcommand:
+        result = app.run(["help"])
+
+    assert result == 42
+    run_subcommand.assert_called_once_with(["help"])
+
+
+def test_version_option_uses_gearbox_version_fallback(capsys, monkeypatch):
+    monkeypatch.setattr(GearBox, "VERSION", "unknown-test")
+    app = GearBox()
+    with pytest.raises(SystemExit):
+        app.run(["--version"])
+    assert "unknown-test" in capsys.readouterr().out

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,6 +11,7 @@ from gearbox.commands.help import HelpAction
 from gearbox.commands.serve import ServeCommand
 from gearbox.commands.setup_app import SetupAppCommand
 from gearbox.main import GearBox, main
+from gearbox.utils.plugins import find_local_distribution
 
 
 def _write_dist_info(
@@ -475,6 +476,54 @@ def test_run_continues_when_project_distribution_is_missing():
 
     assert result == 42
     run_subcommand.assert_called_once_with(["help"])
+
+
+def test_find_local_distribution_continues_after_unreadable_directory(tmp_path):
+    project_root = tmp_path / "project"
+    nested_dir = project_root / "app" / "pkg"
+    nested_dir.mkdir(parents=True)
+
+    plugin_ep = MagicMock(group="gearbox.plugins")
+    dist = MagicMock()
+    dist.entry_points = [plugin_ep]
+
+    def fake_distributions(path):
+        scan_dir = path[0]
+        if scan_dir == str(nested_dir):
+            raise PermissionError("denied")
+        if scan_dir == str(project_root):
+            return [dist]
+        return []
+
+    with patch(
+        "gearbox.utils.plugins.importlib.metadata.distributions",
+        side_effect=fake_distributions,
+    ):
+        found_dist, found_path = find_local_distribution(
+            str(nested_dir), "gearbox.plugins"
+        )
+
+    assert found_dist is dist
+    assert found_path == str(project_root)
+
+
+def test_load_commands_for_package_logs_context_when_distribution_missing(caplog):
+    app = GearBox()
+
+    with patch(
+        "importlib.metadata.packages_distributions",
+        return_value={"tg": ["TurboGears2.devtools"]},
+    ), patch(
+        "importlib.metadata.distribution",
+        side_effect=importlib.metadata.PackageNotFoundError("missing"),
+    ):
+        with caplog.at_level("ERROR", logger="gearbox"):
+            app.load_commands_for_package("tg.devtools")
+
+    assert (
+        "Failed to load project commands for package 'tg.devtools'" in caplog.text
+    )
+    assert "Have you installed your project?" in caplog.text
 
 
 def test_version_option_uses_gearbox_version_fallback(capsys, monkeypatch):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,7 +8,6 @@ import pytest
 
 from gearbox.commandmanager import CommandManager
 from gearbox.commands.help import HelpAction
-from gearbox.commands.scaffold import ScaffoldCommand
 from gearbox.commands.serve import ServeCommand
 from gearbox.commands.setup_app import SetupAppCommand
 from gearbox.main import GearBox, main
@@ -191,6 +190,96 @@ def test_scaffold(tmp_path):
     content = output_file.read_text()
     # Expect the template engine to substitute, e.g., "Testmodel" from {{target.capitalize()}}
     assert "class Testmodel" in content
+
+
+def test_scaffold_derives_output_extension_from_template_name(tmp_path):
+    lookup_dir = tmp_path / "scaffolds"
+    lookup_dir.mkdir()
+    template_file = lookup_dir / "controller.py.template"
+    template_file.write_text("class {{target.capitalize()}}:\n    pass\n")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "gearbox",
+            "scaffold",
+            "controller",
+            "Demo",
+            "-l",
+            str(lookup_dir),
+            "-p",
+            str(project_dir),
+        ],
+    ):
+        main()
+
+    output_file = project_dir / "Demo.py"
+    assert output_file.is_file()
+    assert "class Demo" in output_file.read_text()
+
+
+def test_scaffold_no_package_prevents_subdir_init_file(tmp_path):
+    lookup_dir = tmp_path / "scaffolds"
+    lookup_dir.mkdir()
+    template_file = lookup_dir / "controller.py.template"
+    template_file.write_text("class {{target.capitalize()}}:\n    pass\n")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "gearbox",
+            "scaffold",
+            "controller",
+            "Demo",
+            "-l",
+            str(lookup_dir),
+            "-p",
+            str(project_dir),
+            "-s",
+            "admin",
+            "--no-package",
+        ],
+    ):
+        main()
+
+    assert (project_dir / "admin" / "Demo.py").is_file()
+    assert not (project_dir / "admin" / "__init__.py").exists()
+
+
+def test_scaffold_subdir_creates_package_init_by_default(tmp_path):
+    lookup_dir = tmp_path / "scaffolds"
+    lookup_dir.mkdir()
+    template_file = lookup_dir / "controller.py.template"
+    template_file.write_text("class {{target.capitalize()}}:\n    pass\n")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "gearbox",
+            "scaffold",
+            "controller",
+            "Demo",
+            "-l",
+            str(lookup_dir),
+            "-p",
+            str(project_dir),
+            "-s",
+            "admin",
+        ],
+    ):
+        main()
+
+    assert (project_dir / "admin" / "Demo.py").is_file()
+    assert (project_dir / "admin" / "__init__.py").is_file()
 
 
 # --- Test for patch command ---


### PR DESCRIPTION
Closes #35

- removes `pkg_resources`
- upgrade to support `.dist-info` and not just `.egg-info`
- general refactoring of plugin detection to make it independent from packaging format
- remove support for Python 3.8 and 3.9